### PR TITLE
Add phlyo metrics

### DIFF
--- a/q2_umap/__init__.py
+++ b/q2_umap/__init__.py
@@ -1,3 +1,3 @@
-from q2_umap._method import pipeline, distances
+from q2_umap._method import pipeline, distances, distances_phylogenetic
 
-__all__ = ['pipeline', 'distances']
+__all__ = ['pipeline', 'distances', 'distances_phylogenetic']

--- a/q2_umap/__init__.py
+++ b/q2_umap/__init__.py
@@ -1,3 +1,5 @@
-from q2_umap._method import pipeline, distances, distances_phylogenetic
+from q2_umap._method import pipeline, distances, distances_phylogenetic, \
+    pipeline_phylogenetic
 
-__all__ = ['pipeline', 'distances', 'distances_phylogenetic']
+__all__ = ['pipeline', 'distances', 'distances_phylogenetic',
+           'pipeline_phylogenetic']

--- a/q2_umap/_method.py
+++ b/q2_umap/_method.py
@@ -1,7 +1,6 @@
 import pandas as pd
 import skbio
 import umap
-import unifrac
 from skbio.stats.composition import clr
 from scipy.spatial.distance import euclidean
 from sklearn.metrics.pairwise import _VALID_METRICS as _SK_VALID_METRICS

--- a/q2_umap/_method.py
+++ b/q2_umap/_method.py
@@ -61,6 +61,10 @@ def distances_phylogenetic(table: BIOMV210Format,
                            n_components: int = 3,
                            umap_args: Union[str, dict] = None,
                            bypass_tips: bool = False) -> skbio.DistanceMatrix:
+    if umap_args is None:
+        umap_args = dict()
+    elif isinstance(umap_args, str):
+        umap_args = literal_eval(umap_args)
     dm = beta_phylogenetic(table, phylogeny, umap_metric, n_jobs=n_jobs,
                            variance_adjusted=variance_adjusted, alpha=alpha,
                            bypass_tips=bypass_tips)

--- a/q2_umap/citations.bib
+++ b/q2_umap/citations.bib
@@ -6,3 +6,60 @@
     archivePrefix={arXiv},
     primaryClass={stat.ML}
 }
+
+@article{mcdonald2018unifrac,
+  title={Striped UniFrac: enabling microbiome analysis at unprecedented scale},
+  author={McDonald, Daniel and Vázquez-Baeza, Yoshiki and Koslicki, David and McClelland, Jason and Reeve, Nicolai and Xu, Zhenjiang and Gonzalez, Antonio and Knight, Rob},
+  journal={Nature Methods},
+  year={2018},
+  publisher={Nature Publishing Group},
+  doi={10.1038/s41592-018-0187-8}
+}
+
+@article{lozupone2005unifrac,
+  title={UniFrac: a new phylogenetic method for comparing microbial communities},
+  author={Lozupone, Catherine and Knight, Rob},
+  journal={Applied and environmental microbiology},
+  volume={71},
+  number={12},
+  pages={8228--8235},
+  year={2005},
+  publisher={Am Soc Microbiol},
+  doi={10.1128/AEM.71.12.8228-8235.2005}
+}
+
+@article{lozupone2007quantitative,
+  title={Quantitative and qualitative $\beta$ diversity measures lead to different insights into factors that structure microbial communities},
+  author={Lozupone, Catherine A and Hamady, Micah and Kelley, Scott T and Knight, Rob},
+  journal={Applied and environmental microbiology},
+  volume={73},
+  number={5},
+  pages={1576--1585},
+  year={2007},
+  publisher={Am Soc Microbiol},
+  doi={10.1128/AEM.01996-06}
+}
+
+@article{chang2011variance,
+  title={Variance adjusted weighted UniFrac: a powerful beta diversity measure for comparing communities based on phylogeny},
+  author={Chang, Qin and Luan, Yihui and Sun, Fengzhu},
+  journal={BMC bioinformatics},
+  volume={12},
+  number={1},
+  pages={118},
+  year={2011},
+  publisher={BioMed Central},
+  doi={https://doi.org/10.1186/1471-2105-12-118}
+}
+
+@article{chen2012associating,
+  title={Associating microbiome composition with environmental covariates using generalized UniFrac distances},
+  author={Chen, Jun and Bittinger, Kyle and Charlson, Emily S and Hoffmann, Christian and Lewis, James and Wu, Gary D and Collman, Ronald G and Bushman, Frederic D and Li, Hongzhe},
+  journal={Bioinformatics},
+  volume={28},
+  number={16},
+  pages={2106--2113},
+  year={2012},
+  publisher={Oxford University Press},
+  doi={10.1093/bioinformatics/bts342}
+}

--- a/q2_umap/plugin_setup.py
+++ b/q2_umap/plugin_setup.py
@@ -73,6 +73,83 @@ plugin.pipelines.register_function(
                 'feature table using UMAP embeddings.'
 )
 
+plugin.pipelines.register_function(
+    function=q2_umap.pipeline_phylogenetic,
+    inputs={
+        'table': FeatureTable[Frequency],
+        'phylogeny': Phylogeny[Rooted],
+    },
+    parameters={
+        'metadata': Metadata,
+        'umap_metric': Str,
+        'n_components': Int,
+        'umap_args': Str,
+        'sampling_depth': Int % Range(1, None),
+        'with_replacement': Bool,
+        'n_jobs': Int,
+        'variance_adjusted': Bool,
+        'alpha': Float % Range(0, 1, inclusive_end=True),
+        'bypass_tips': Bool,
+    },
+    outputs=[
+        ('rarefied_table', FeatureTable[Frequency]),
+        ('distance_matrix', DistanceMatrix),
+        ('pcoa_results', PCoAResults),
+        ('emperor', Visualization),
+    ],
+    input_descriptions={
+        'table': ('The feature table containing the samples over which UMAP '
+                  'distances should be computed.'),
+        'phylogeny': ('Phylogenetic tree containing tip identifiers that '
+                      'correspond to the feature identifiers in the table. '
+                      'This tree can contain tip ids that are not present in '
+                      'the table, but all feature ids in the table must be '
+                      'present in this tree.')
+    },
+    parameter_descriptions={
+        'metadata': 'The sample metadata to use in the emperor plots.',
+        'umap_metric': 'The metric to use within the UMAP algorithm.',
+        'n_jobs': 'The number of workers to use.',
+        'variance_adjusted': ('Perform variance adjustment based on Chang et '
+                              'al. BMC Bioinformatics 2011. Weights distances '
+                              'based on the proportion of the relative '
+                              'abundance represented between the samples at a'
+                              ' given node under evaluation.'),
+        'alpha': ('This parameter is only used when the choice of metric is '
+                  'generalized_unifrac. The value of alpha controls importance'
+                  ' of sample proportions. 1.0 is weighted normalized UniFrac.'
+                  ' 0.0 is close to unweighted UniFrac, but only if the sample'
+                  ' proportions are dichotomized.'),
+        'bypass_tips': ('In a bifurcating tree, the tips make up about 50% of '
+                        'the nodes in a tree. By ignoring them, specificity '
+                        'can be traded for reduced compute time. This has the'
+                        ' effect of collapsing the phylogeny, and is analogous'
+                        ' (in concept) to moving from 99% to 97% OTUs'),
+        'n_components': 'The number of components to use for UMAP embeddings',
+        'umap_args': 'Additional arguments to passed into UMAP',
+        'sampling_depth': 'The total frequency that each sample should be '
+                          'rarefied to prior to computing distance metric.',
+        'with_replacement': 'Rarefy with replacement by sampling from the '
+                            'multinomial distribution instead of rarefying '
+                            'without replacement.',
+    },
+    output_descriptions={
+        'rarefied_table':
+            'The resulting rarefied feature table (if sampling depth is '
+            'specified). Otherwise, it is the original table.',
+        'distance_matrix':
+            'Matrix of distances between UMAP embeddings.',
+        'pcoa_results':
+            'PCoA matrix computed from distances between UMAP embeddings '
+            'for each sample.',
+        'emperor':
+            'Emperor plot of the PCoA matrix computed from UMAP embeddings.',
+    },
+    name='UMAP Pipeline',
+    description='Applies a steps to ordinate and visualize samples in a '
+                'feature table using UMAP embeddings.'
+)
+
 plugin.methods.register_function(
     function=q2_umap.distances,
     inputs={

--- a/q2_umap/tests/base.py
+++ b/q2_umap/tests/base.py
@@ -1,0 +1,31 @@
+import unittest
+import pkg_resources
+import os
+import shutil
+
+
+class TestCase(unittest.TestCase):
+
+    def setUp(self) -> None:
+        self.to_remove = []
+
+    def get_data_path(self, filename):
+        # adapted from qiime2.plugin.testing.TestPluginBase and biocore/unifrac
+        return pkg_resources.resource_filename(self.package,
+                                               'data/%s' % filename)
+
+    def create_data_path(self, filename):
+        file_path = self.get_data_path(filename)
+        dir_path = os.path.split(file_path)[0]
+        if not os.path.isdir(dir_path):
+            os.makedirs(dir_path)
+            self.to_remove.append(dir_path)
+        self.to_remove.append(file_path)
+        return file_path
+
+    def tearDown(self) -> None:
+        for path in self.to_remove:
+            if os.path.isfile(path):
+                os.remove(path)
+            elif os.path.isdir(path):
+                shutil.rmtree(path)

--- a/q2_umap/tests/base.py
+++ b/q2_umap/tests/base.py
@@ -17,10 +17,10 @@ class TestCase(unittest.TestCase):
     def create_data_path(self, filename):
         file_path = self.get_data_path(filename)
         dir_path = os.path.split(file_path)[0]
+        self.to_remove.append(file_path)
         if not os.path.isdir(dir_path):
             os.makedirs(dir_path)
             self.to_remove.append(dir_path)
-        self.to_remove.append(file_path)
         return file_path
 
     def tearDown(self) -> None:

--- a/q2_umap/tests/test_method.py
+++ b/q2_umap/tests/test_method.py
@@ -90,3 +90,9 @@ class TestUMAPDistancesPhylogenetic(test_base.TestCase):
                                     umap_metric='unweighted_unifrac',
                                     umap_args=umap_kwargs)
         self.assertEqual(dm.shape, (6, 6))
+
+    def test_umap_phylogenetic_no_args(self):
+        dm = distances_phylogenetic(self.table_path, self.tree_path,
+                                    'unweighted_unifrac')
+        self.assertEqual(dm.shape, (6, 6))
+

--- a/q2_umap/tests/test_method.py
+++ b/q2_umap/tests/test_method.py
@@ -95,4 +95,3 @@ class TestUMAPDistancesPhylogenetic(test_base.TestCase):
         dm = distances_phylogenetic(self.table_path, self.tree_path,
                                     'unweighted_unifrac')
         self.assertEqual(dm.shape, (6, 6))
-

--- a/q2_umap/tests/test_method.py
+++ b/q2_umap/tests/test_method.py
@@ -1,4 +1,3 @@
-import unittest
 import io
 
 import skbio

--- a/q2_umap/tests/test_plugin.py
+++ b/q2_umap/tests/test_plugin.py
@@ -131,7 +131,7 @@ class TestUMAPDistancesPhylogeneticPlugin(TestPluginBase, test_base.TestCase):
 
     def test_distances(self):
         table = Artifact.import_data('FeatureTable[Frequency]', self.data)
-        tree = Artifact.import_data('Taxonomy[Rooted]', self.tree)
+        tree = Artifact.import_data('Phylogeny[Rooted]', self.tree)
         results = self.distance(table, tree, 'unweighted_unifrac',
                                 umap_args="{'n_neighbors': 3}")
         self.assertEqual(repr(results.distance_matrix.type), 'DistanceMatrix')

--- a/q2_umap/tests/test_plugin.py
+++ b/q2_umap/tests/test_plugin.py
@@ -27,7 +27,6 @@ class TestUMAPPipeline(TestPluginBase):
                          index=pd.Index(['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
                                         name='id')))
         self.pipeline = self.plugin.pipelines['pipeline']
-        self.distance = self.plugin.methods['distances']
 
     def test_pipeline_all_results(self):
         table = Artifact.import_data('FeatureTable[Frequency]', self.data)
@@ -78,8 +77,94 @@ class TestUMAPPipeline(TestPluginBase):
         self.assertEqual(repr(results.emperor.type), 'Visualization')
 
 
+class TestUMAPPipelinePhylogenetic(TestPluginBase, test_base.TestCase):
+
+    package = 'q2_umap.tests'
+
+    def setUp(self):
+        TestPluginBase.setUp(self)
+        test_base.TestCase.setUp(self)
+        self.data = pd.DataFrame([[1, 2, 0, 4],
+                                  [1, 4, 3, 5],
+                                  [0, 0, 1, 2],
+                                  [0, 1, 2, 1],
+                                  [1, 2, 2, 0],
+                                  [0, 1, 1, 0]],
+                                 index=['S1', 'S2', 'S3', 'S4', 'S5',
+                                        'S6'],
+                                 columns=['O1', 'O2', 'O3', 'O4'])
+        self.tree = skbio.TreeNode.read(io.StringIO(
+            '((O1:0.25, (O4:0.25, O2:0.50):0.1):0.25, O3:0.75)root;'))
+        self.metadata = Metadata(
+            pd.DataFrame({'foo': ['1', '2', '3', '4', '5', '6']},
+                         index=pd.Index(
+                             ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
+                             name='id')))
+        self.pipeline = self.plugin.pipelines['pipeline_phylogenetic']
+
+    def test_pipeline_phylogenetic_all_results(self):
+        table = Artifact.import_data('FeatureTable[Frequency]', self.data)
+        tree = Artifact.import_data('Phylogeny[Rooted]', self.tree)
+        results = self.pipeline(table, tree, metadata=self.metadata,
+                                umap_metric='unweighted_unifrac',
+                                umap_args="{'n_neighbors': 3}")
+        self.assertEqual(len(results), 4)
+
+    def test_pipeline_phylogenetic_rarefied_table_no_rarefy(self):
+        table = Artifact.import_data('FeatureTable[Frequency]', self.data)
+        tree = Artifact.import_data('Phylogeny[Rooted]', self.tree)
+        results = self.pipeline(table, tree, metadata=self.metadata,
+                                umap_metric='unweighted_unifrac',
+                                umap_args="{'n_neighbors': 3}")
+        self.assertEqual(repr(results.rarefied_table.type),
+                         'FeatureTable[Frequency]')
+        raw_table = table.view(pd.DataFrame)
+        no_rarefy_table = results.rarefied_table.view(pd.DataFrame)
+        pdt.assert_frame_equal(raw_table, no_rarefy_table)
+
+    def test_pipeline_phylogenetic_rarefied_table_with_rarefy(self):
+        table = Artifact.import_data('FeatureTable[Frequency]', self.data)
+        tree = Artifact.import_data('Phylogeny[Rooted]', self.tree)
+        sampling_depth = 2
+        results = self.pipeline(table, tree, metadata=self.metadata,
+                                umap_metric='unweighted_unifrac',
+                                umap_args="{'n_neighbors': 3}",
+                                sampling_depth=sampling_depth)
+        self.assertEqual(repr(results.rarefied_table.type),
+                         'FeatureTable[Frequency]')
+        rarefied_table = results.rarefied_table.view(pd.DataFrame)
+        sample_sums = rarefied_table.sum(axis='columns')
+        self.assertTrue((sample_sums == sampling_depth).all())
+
+    def test_pipeline_phylogenetic_dm(self):
+        table = Artifact.import_data('FeatureTable[Frequency]', self.data)
+        tree = Artifact.import_data('Phylogeny[Rooted]', self.tree)
+        results = self.pipeline(table, tree, metadata=self.metadata,
+                                umap_metric='unweighted_unifrac',
+                                umap_args="{'n_neighbors': 3}")
+        self.assertEqual(repr(results.distance_matrix.type),
+                         'DistanceMatrix')
+
+    def test_pipeline_phylogenetic_pcoa(self):
+        table = Artifact.import_data('FeatureTable[Frequency]', self.data)
+        tree = Artifact.import_data('Phylogeny[Rooted]', self.tree)
+        results = self.pipeline(table, tree, metadata=self.metadata,
+                                umap_metric='unweighted_unifrac',
+                                umap_args="{'n_neighbors': 3}")
+        self.assertEqual(repr(results.pcoa_results.type),
+                         'PCoAResults')
+
+    def test_pipeline_phylogenetic_emperor(self):
+        table = Artifact.import_data('FeatureTable[Frequency]', self.data)
+        tree = Artifact.import_data('Phylogeny[Rooted]', self.tree)
+        results = self.pipeline(table, tree, metadata=self.metadata,
+                                umap_metric='unweighted_unifrac',
+                                umap_args="{'n_neighbors': 3}")
+        self.assertEqual(repr(results.emperor.type), 'Visualization')
+
+
 class TestUMAPDistancesPlugin(TestPluginBase):
-    package = 'q2_umap'
+    package = 'q2_umap.tests'
 
     def setUp(self):
         super().setUp()
@@ -106,7 +191,7 @@ class TestUMAPDistancesPlugin(TestPluginBase):
 
 
 class TestUMAPDistancesPhylogeneticPlugin(TestPluginBase, test_base.TestCase):
-    package = 'q2_umap'
+    package = 'q2_umap.tests'
 
     def setUp(self):
         TestPluginBase.setUp(self)

--- a/q2_umap/tests/test_plugin.py
+++ b/q2_umap/tests/test_plugin.py
@@ -1,12 +1,16 @@
+import io
+
+import skbio
 import pandas as pd
+import q2_umap.tests.base as test_base
+import pandas.testing as pdt
 from qiime2 import Metadata, Artifact
 from qiime2.plugin.testing import TestPluginBase
-import pandas.testing as pdt
 
 
 class TestUMAPPipeline(TestPluginBase):
 
-    package = 'q2_umap'
+    package = 'q2_umap.tests'
 
     def setUp(self):
         super().setUp()
@@ -74,7 +78,7 @@ class TestUMAPPipeline(TestPluginBase):
         self.assertEqual(repr(results.emperor.type), 'Visualization')
 
 
-class TestUMAPDistances(TestPluginBase):
+class TestUMAPDistancesPlugin(TestPluginBase):
     package = 'q2_umap'
 
     def setUp(self):
@@ -98,4 +102,36 @@ class TestUMAPDistances(TestPluginBase):
     def test_distances(self):
         table = Artifact.import_data('FeatureTable[Frequency]', self.data)
         results = self.distance(table, umap_args="{'n_neighbors': 3}")
+        self.assertEqual(repr(results.distance_matrix.type), 'DistanceMatrix')
+
+
+class TestUMAPDistancesPhylogeneticPlugin(TestPluginBase, test_base.TestCase):
+    package = 'q2_umap'
+
+    def setUp(self):
+        TestPluginBase.setUp(self)
+        test_base.TestCase.setUp(self)
+        self.data = pd.DataFrame([[1, 2, 0, 4],
+                                  [1, 4, 3, 5],
+                                  [0, 0, 1, 2],
+                                  [0, 1, 2, 1],
+                                  [1, 2, 2, 0],
+                                  [0, 1, 1, 0]],
+                                 index=['S1', 'S2', 'S3', 'S4', 'S5',
+                                        'S6'],
+                                 columns=['O1', 'O2', 'O3', 'O4'])
+        self.tree = skbio.TreeNode.read(io.StringIO(
+            '((O1:0.25, (O4:0.25, O2:0.50):0.1):0.25, O3:0.75)root;'))
+        self.metadata = Metadata(
+            pd.DataFrame({'foo': ['1', '2', '3', '4', '5', '6']},
+                         index=pd.Index(
+                             ['S1', 'S2', 'S3', 'S4', 'S5', 'S6'],
+                             name='id')))
+        self.distance = self.plugin.methods['distances_phylogenetic']
+
+    def test_distances(self):
+        table = Artifact.import_data('FeatureTable[Frequency]', self.data)
+        tree = Artifact.import_data('Taxonomy[Rooted]', self.tree)
+        results = self.distance(table, tree, 'unweighted_unifrac',
+                                umap_args="{'n_neighbors': 3}")
         self.assertEqual(repr(results.distance_matrix.type), 'DistanceMatrix')


### PR DESCRIPTION
Fixes #7 

Adds a method for computing umap embeddings on phylogenetic distances, as well as a pipeline for streamlining the creating of downstream analyses on the UMAP distance matrices.